### PR TITLE
Feat: add via prop to solve ubiquity

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -15,7 +15,7 @@ export namespace Components {
      */
     interface ZanitMenubar {
         /**
-          * ID of the current active item.
+          * Path of the current item.
           * @default undefined
          */
         "current": string | undefined;
@@ -33,21 +33,16 @@ export namespace Components {
           * @default undefined
          */
         "searchQuery": string | undefined;
-        /**
-          * The path of current item, used to solve ubiquity and determine the right active element.
-          * @default undefined
-         */
-        "via": string | undefined;
     }
     /**
      * Mobile menubar component.
      */
     interface ZanitMobileMenubar {
         /**
-          * ID of the current active item.
-          * @default undefined
+          * IDs path of the current item.
+          * @default []
          */
-        "current": string | undefined;
+        "currentPath": string[];
         /**
           * Menubar items.
           * @default []
@@ -63,11 +58,6 @@ export namespace Components {
           * @default undefined
          */
         "searchQuery": string | undefined;
-        /**
-          * The path of the current item, used to solve ubiquity and determine the right active element.
-          * @default undefined
-         */
-        "via": string | undefined;
     }
     interface ZanitSearchForm {
         /**
@@ -134,7 +124,7 @@ declare namespace LocalJSX {
      */
     interface ZanitMenubar {
         /**
-          * ID of the current active item.
+          * Path of the current item.
           * @default undefined
          */
         "current"?: string | undefined;
@@ -152,21 +142,16 @@ declare namespace LocalJSX {
           * @default undefined
          */
         "searchQuery"?: string | undefined;
-        /**
-          * The path of current item, used to solve ubiquity and determine the right active element.
-          * @default undefined
-         */
-        "via"?: string | undefined;
     }
     /**
      * Mobile menubar component.
      */
     interface ZanitMobileMenubar {
         /**
-          * ID of the current active item.
-          * @default undefined
+          * IDs path of the current item.
+          * @default []
          */
-        "current"?: string | undefined;
+        "currentPath"?: string[];
         /**
           * Menubar items.
           * @default []
@@ -182,11 +167,6 @@ declare namespace LocalJSX {
           * @default undefined
          */
         "searchQuery"?: string | undefined;
-        /**
-          * The path of the current item, used to solve ubiquity and determine the right active element.
-          * @default undefined
-         */
-        "via"?: string | undefined;
     }
     interface ZanitSearchForm {
         "onResetSearch"?: (event: ZanitSearchFormCustomEvent<void>) => void;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -33,6 +33,11 @@ export namespace Components {
           * @default undefined
          */
         "searchQuery": string | undefined;
+        /**
+          * The path of current item, used to solve ubiquity and determine the right active element.
+          * @default undefined
+         */
+        "via": string | undefined;
     }
     /**
      * Mobile menubar component.
@@ -58,6 +63,11 @@ export namespace Components {
           * @default undefined
          */
         "searchQuery": string | undefined;
+        /**
+          * The path of the current item, used to solve ubiquity and determine the right active element.
+          * @default undefined
+         */
+        "via": string | undefined;
     }
     interface ZanitSearchForm {
         /**
@@ -142,6 +152,11 @@ declare namespace LocalJSX {
           * @default undefined
          */
         "searchQuery"?: string | undefined;
+        /**
+          * The path of current item, used to solve ubiquity and determine the right active element.
+          * @default undefined
+         */
+        "via"?: string | undefined;
     }
     /**
      * Mobile menubar component.
@@ -167,6 +182,11 @@ declare namespace LocalJSX {
           * @default undefined
          */
         "searchQuery"?: string | undefined;
+        /**
+          * The path of the current item, used to solve ubiquity and determine the right active element.
+          * @default undefined
+         */
+        "via"?: string | undefined;
     }
     interface ZanitSearchForm {
         "onResetSearch"?: (event: ZanitSearchFormCustomEvent<void>) => void;

--- a/src/components/menubar/menu/menu.tsx
+++ b/src/components/menubar/menu/menu.tsx
@@ -6,12 +6,14 @@ import { MenuItem } from '../../../utils/types';
  * @member {string} controlledBy - The HTML id of the element that controls the menu.
  * @member {MenuItem[]} items - The items to show in the menu.
  * @member {string} current - The id of the current active item.
+ * @member {string | undefined} via - The path of current item, used to solve ubiquity and determine the right active element.
  * @member {function} onItemKeyDown - The function to call when a key is pressed from a menuitem.
  */
 export interface MenuProps {
   controlledBy?: string;
   items?: MenuItem[];
   current?: string;
+  via?: string | undefined;
   onItemKeyDown?: (event: KeyboardEvent) => void;
 }
 
@@ -41,12 +43,16 @@ const getGroupedItems = (items: MenuItem[]) => {
 /**
  * Floating menu component. It shows a list of items that can be grouped.
  */
-export const Menu: FunctionalComponent<MenuProps> = ({ controlledBy, items, current, onItemKeyDown }) => {
+export const Menu: FunctionalComponent<MenuProps> = ({ controlledBy, items, current, via, onItemKeyDown }) => {
   if (!items?.length) {
     return null;
   }
 
   const groups = getGroupedItems(items);
+
+  const isActive = (item: MenuItem) => {
+    return via ? current === item.id && via.includes(controlledBy) : current === item.id;
+  };
 
   return (
     <div
@@ -80,7 +86,10 @@ export const Menu: FunctionalComponent<MenuProps> = ({ controlledBy, items, curr
                 <li role="none">
                   {item.href && (
                     <a
-                      class={{ 'menu-item': true, 'active': current === item.id }}
+                      class={{
+                        'menu-item': true,
+                        'active': isActive(item),
+                      }}
                       href={item.href}
                       role="menuitem"
                       tabIndex={-1}

--- a/src/components/menubar/menu/menu.tsx
+++ b/src/components/menubar/menu/menu.tsx
@@ -5,15 +5,13 @@ import { MenuItem } from '../../../utils/types';
  * Menu of items that can be grouped.
  * @member {string} controlledBy - The HTML id of the element that controls the menu.
  * @member {MenuItem[]} items - The items to show in the menu.
- * @member {string} current - The id of the current active item.
- * @member {string | undefined} via - The path of current item, used to solve ubiquity and determine the right active element.
+ * @member {string[]} currentPath - Path of current item.
  * @member {function} onItemKeyDown - The function to call when a key is pressed from a menuitem.
  */
 export interface MenuProps {
   controlledBy?: string;
   items?: MenuItem[];
-  current?: string;
-  via?: string | undefined;
+  currentPath?: string[];
   onItemKeyDown?: (event: KeyboardEvent) => void;
 }
 
@@ -43,16 +41,14 @@ const getGroupedItems = (items: MenuItem[]) => {
 /**
  * Floating menu component. It shows a list of items that can be grouped.
  */
-export const Menu: FunctionalComponent<MenuProps> = ({ controlledBy, items, current, via, onItemKeyDown }) => {
+export const Menu: FunctionalComponent<MenuProps> = ({ controlledBy, items, currentPath = [], onItemKeyDown }) => {
   if (!items?.length) {
     return null;
   }
 
   const groups = getGroupedItems(items);
 
-  const isActive = (item: MenuItem) => {
-    return via ? current === item.id && via.includes(controlledBy) : current === item.id;
-  };
+  const isActive = (item: MenuItem) => currentPath.includes(controlledBy) && currentPath.includes(item.id);
 
   return (
     <div
@@ -93,7 +89,7 @@ export const Menu: FunctionalComponent<MenuProps> = ({ controlledBy, items, curr
                       href={item.href}
                       role="menuitem"
                       tabIndex={-1}
-                      aria-current={current === item.id ? 'page' : 'false'}
+                      aria-current={isActive(item) ? 'page' : 'false'}
                       onKeyDown={(event) => onItemKeyDown(event)}
                     >
                       {item.label}

--- a/src/components/menubar/menubar.css
+++ b/src/components/menubar/menubar.css
@@ -150,10 +150,6 @@ we put the same text already bold with height 0, so as to always occupy the maxi
   visibility: hidden;
 }
 
-.sub-menubar:not(.visible) {
-  display: none;
-}
-
 /* active item bottom border */
 .sub-menubar .menubar-item.active::after {
   position: absolute;

--- a/src/components/menubar/menubar.tsx
+++ b/src/components/menubar/menubar.tsx
@@ -470,7 +470,7 @@ export class ZanitMenubar {
                         item.menuItems?.length ? (this.openMenu === item.id ? 'true' : 'false') : undefined
                       }
                       aria-haspopup={item.menuItems?.length ? 'true' : 'false'}
-                      aria-current={this.current === item.id ? 'page' : 'false'}
+                      aria-current={this.current.includes(item.id) ? 'page' : 'false'}
                       onPointerOver={() => this.showMenu(item)}
                       onKeyDown={(event) => this.handleItemKeydown(event, item)}
                     >
@@ -530,7 +530,7 @@ export class ZanitMenubar {
                             aria-expanded={
                               subitem.menuItems?.length ? (this.openMenu === subitem.id ? 'true' : 'false') : undefined
                             }
-                            aria-current={this.current === item.id ? 'page' : 'false'}
+                            aria-current={this.current.includes(subitem.id) ? 'page' : 'false'}
                             onPointerOver={() => this.showMenu(subitem)}
                             onKeyDown={(event) => this.handleItemKeydown(event, subitem)}
                           >

--- a/src/components/menubar/mobile-menubar/mobile-menubar.tsx
+++ b/src/components/menubar/mobile-menubar/mobile-menubar.tsx
@@ -12,11 +12,8 @@ import { Menu } from '../menu/menu';
 export class ZanitMobileMenubar {
   @Element() host: HTMLZanitMobileMenubarElement;
 
-  /** ID of the current active item. */
-  @Prop() current: string | undefined = undefined;
-
-  /** The path of the current item, used to solve ubiquity and determine the right active element. */
-  @Prop() via: string | undefined = undefined;
+  /** IDs path of the current item. */
+  @Prop() currentPath: string[] = [];
 
   /** Menubar items. */
   @Prop() items: MenubarItem[] = [];
@@ -27,6 +24,8 @@ export class ZanitMobileMenubar {
   /** Whether the menubar is loading the data. */
   @Prop() loading: boolean = false;
 
+  /** Last active item ID. */
+  @State() lastCurrent: string | undefined = undefined;
   @State() parentItem: MenubarItem | undefined = undefined;
   @State() menuItems: MenubarItem[] | MenuItem[] | undefined = undefined;
   /** Whether the items to render come from a menubar or a menu. */
@@ -34,38 +33,38 @@ export class ZanitMobileMenubar {
   @State() open: boolean;
 
   @Watch('items')
-  @Watch('current')
+  @Watch('currentPath')
   onItemsChange() {
+    this.lastCurrent = this.currentPath?.length ? this.currentPath?.[this.currentPath.length - 1] : undefined;
     this.setupData(this.items);
   }
 
   /**
    * Find the current item and take its parent, `menuItems` or the `navbarItems`.
-   * @returns True if an item matches the `current` prop, false otherwise.
    */
-  private setupData(items: MenubarItem[], parent?: MenubarItem): boolean {
+  private setupData(items: MenubarItem[], parent?: MenubarItem) {
     for (const item of items) {
-      if (item.id === this.current) {
-        const type = item.menuItems?.length ? 'menu' : 'menubar';
+      if (item.id === this.lastCurrent) {
         this.parentItem = parent;
-        this.menuType = type;
+        this.menuType = item.menuItems?.length ? 'menu' : 'menubar';
         this.menuItems = item.menuItems || item.navbarItems;
-        return true;
+        return;
       }
 
-      if (item.menuItems?.some(({ id }) => id === this.current)) {
-        this.parentItem = parent;
-        this.menuType = 'menu';
-        this.menuItems = item.menuItems;
-        return true;
+      if (
+        item.id === this.currentPath[this.currentPath.length - 2] &&
+        item.menuItems?.some(({ id }) => id === this.lastCurrent)
+      ) {
+        this.parentItem = item;
+        this.menuType = item.menuItems?.length ? 'menu' : 'menubar';
+        this.menuItems = item.menuItems || item.navbarItems;
+        return;
       }
 
       if (item.navbarItems?.length) {
         return this.setupData(item.navbarItems, item);
       }
     }
-
-    return false;
   }
 
   private get menuItemsElement() {
@@ -126,6 +125,7 @@ export class ZanitMobileMenubar {
   }
 
   connectedCallback() {
+    this.lastCurrent = this.currentPath?.length ? this.currentPath?.[this.currentPath.length - 1] : undefined;
     this.setupData(this.items);
   }
 
@@ -201,7 +201,7 @@ export class ZanitMobileMenubar {
               />
             </li>
 
-            {!this.loading && this.current && (
+            {!this.loading && this.currentPath && (
               <li role="none">
                 <a
                   class="parent"
@@ -245,8 +245,8 @@ export class ZanitMobileMenubar {
             {this.menuType === 'menu' ? (
               <Menu
                 items={this.menuItems}
-                current={this.current}
-                via={this.via}
+                controlledBy={this.parentItem?.id}
+                currentPath={this.currentPath}
                 onItemKeyDown={(event) => this.handleItemKeydown(event)}
               />
             ) : (
@@ -265,7 +265,7 @@ export class ZanitMobileMenubar {
                         href={item.href}
                         id={item.id}
                         role="menuitem"
-                        aria-current={this.current === item.id ? 'page' : 'false'}
+                        aria-current={this.lastCurrent === item.id ? 'page' : 'false'}
                         tabIndex={-1}
                         onKeyDown={(event) => this.handleItemKeydown(event)}
                       >

--- a/src/components/menubar/mobile-menubar/mobile-menubar.tsx
+++ b/src/components/menubar/mobile-menubar/mobile-menubar.tsx
@@ -51,18 +51,15 @@ export class ZanitMobileMenubar {
         return;
       }
 
-      if (
-        item.id === this.currentPath[this.currentPath.length - 2] &&
-        item.menuItems?.some(({ id }) => id === this.lastCurrent)
-      ) {
+      if (item.menuItems && item.menuItems.some((child) => child.id === this.lastCurrent)) {
         this.parentItem = item;
-        this.menuType = item.menuItems?.length ? 'menu' : 'menubar';
+        this.menuType = item.menuItems.length ? 'menu' : 'menubar';
         this.menuItems = item.menuItems || item.navbarItems;
         return;
       }
 
       if (item.navbarItems?.length) {
-        return this.setupData(item.navbarItems, item);
+        this.setupData(item.navbarItems, item);
       }
     }
   }

--- a/src/components/menubar/mobile-menubar/mobile-menubar.tsx
+++ b/src/components/menubar/mobile-menubar/mobile-menubar.tsx
@@ -51,15 +51,18 @@ export class ZanitMobileMenubar {
         return;
       }
 
-      if (item.menuItems && item.menuItems.some((child) => child.id === this.lastCurrent)) {
+      if (
+        item.id === this.currentPath[this.currentPath.length - 2] &&
+        item.menuItems?.some(({ id }) => id === this.lastCurrent)
+      ) {
         this.parentItem = item;
-        this.menuType = item.menuItems.length ? 'menu' : 'menubar';
+        this.menuType = item.menuItems?.length ? 'menu' : 'menubar';
         this.menuItems = item.menuItems || item.navbarItems;
         return;
       }
 
       if (item.navbarItems?.length) {
-        this.setupData(item.navbarItems, item);
+        return this.setupData(item.navbarItems, item);
       }
     }
   }

--- a/src/components/menubar/mobile-menubar/mobile-menubar.tsx
+++ b/src/components/menubar/mobile-menubar/mobile-menubar.tsx
@@ -52,6 +52,7 @@ export class ZanitMobileMenubar {
       }
 
       if (
+        this.currentPath.length > 1 &&
         item.id === this.currentPath[this.currentPath.length - 2] &&
         item.menuItems?.some(({ id }) => id === this.lastCurrent)
       ) {

--- a/src/components/menubar/mobile-menubar/mobile-menubar.tsx
+++ b/src/components/menubar/mobile-menubar/mobile-menubar.tsx
@@ -15,6 +15,9 @@ export class ZanitMobileMenubar {
   /** ID of the current active item. */
   @Prop() current: string | undefined = undefined;
 
+  /** The path of the current item, used to solve ubiquity and determine the right active element. */
+  @Prop() via: string | undefined = undefined;
+
   /** Menubar items. */
   @Prop() items: MenubarItem[] = [];
 
@@ -243,6 +246,7 @@ export class ZanitMobileMenubar {
               <Menu
                 items={this.menuItems}
                 current={this.current}
+                via={this.via}
                 onItemKeyDown={(event) => this.handleItemKeydown(event)}
               />
             ) : (

--- a/src/components/menubar/mobile-menubar/readme.md
+++ b/src/components/menubar/mobile-menubar/readme.md
@@ -11,13 +11,12 @@ Mobile menubar component.
 
 ## Properties
 
-| Property      | Attribute      | Description                                                                                  | Type            | Default     |
-| ------------- | -------------- | -------------------------------------------------------------------------------------------- | --------------- | ----------- |
-| `current`     | `current`      | ID of the current active item.                                                               | `string`        | `undefined` |
-| `items`       | `items`        | Menubar items.                                                                               | `MenubarItem[]` | `[]`        |
-| `loading`     | `loading`      | Whether the menubar is loading the data.                                                     | `boolean`       | `false`     |
-| `searchQuery` | `search-query` | Initial search query.                                                                        | `string`        | `undefined` |
-| `via`         | `via`          | The path of the current item, used to solve ubiquity and determine the right active element. | `string`        | `undefined` |
+| Property      | Attribute      | Description                              | Type            | Default     |
+| ------------- | -------------- | ---------------------------------------- | --------------- | ----------- |
+| `currentPath` | `current-path` | IDs path of the current item.            | `string[]`      | `[]`        |
+| `items`       | `items`        | Menubar items.                           | `MenubarItem[]` | `[]`        |
+| `loading`     | `loading`      | Whether the menubar is loading the data. | `boolean`       | `false`     |
+| `searchQuery` | `search-query` | Initial search query.                    | `string`        | `undefined` |
 
 
 ## Dependencies

--- a/src/components/menubar/mobile-menubar/readme.md
+++ b/src/components/menubar/mobile-menubar/readme.md
@@ -11,12 +11,13 @@ Mobile menubar component.
 
 ## Properties
 
-| Property      | Attribute      | Description                              | Type            | Default     |
-| ------------- | -------------- | ---------------------------------------- | --------------- | ----------- |
-| `current`     | `current`      | ID of the current active item.           | `string`        | `undefined` |
-| `items`       | `items`        | Menubar items.                           | `MenubarItem[]` | `[]`        |
-| `loading`     | `loading`      | Whether the menubar is loading the data. | `boolean`       | `false`     |
-| `searchQuery` | `search-query` | Initial search query.                    | `string`        | `undefined` |
+| Property      | Attribute      | Description                                                                                  | Type            | Default     |
+| ------------- | -------------- | -------------------------------------------------------------------------------------------- | --------------- | ----------- |
+| `current`     | `current`      | ID of the current active item.                                                               | `string`        | `undefined` |
+| `items`       | `items`        | Menubar items.                                                                               | `MenubarItem[]` | `[]`        |
+| `loading`     | `loading`      | Whether the menubar is loading the data.                                                     | `boolean`       | `false`     |
+| `searchQuery` | `search-query` | Initial search query.                                                                        | `string`        | `undefined` |
+| `via`         | `via`          | The path of the current item, used to solve ubiquity and determine the right active element. | `string`        | `undefined` |
 
 
 ## Dependencies

--- a/src/components/menubar/readme.md
+++ b/src/components/menubar/readme.md
@@ -16,6 +16,7 @@ When a main menubar item is the current active one, a sub-menubar is shown and e
 | `data`            | `data`              | The data to build the menu (as an array of `MenubarItem` or a JSON array) or the url to fetch to retrieve it.                                          | `MenubarItem[] \| Promise<MenubarItem[]> \| URL \| string` | `undefined` |
 | `mouseOutTimeout` | `mouse-out-timeout` | Delay in milliseconds before closing the menu after a mouseout event. Useful to avoid immediate closing when the pointer briefly leaves the component. | `number`                                                   | `1000`      |
 | `searchQuery`     | `search-query`      | Initial search query.                                                                                                                                  | `string`                                                   | `undefined` |
+| `via`             | `via`               | The path of current item, used to solve ubiquity and determine the right active element.                                                               | `string`                                                   | `undefined` |
 
 
 ## Dependencies

--- a/src/components/menubar/readme.md
+++ b/src/components/menubar/readme.md
@@ -12,11 +12,10 @@ When a main menubar item is the current active one, a sub-menubar is shown and e
 
 | Property          | Attribute           | Description                                                                                                                                            | Type                                                       | Default     |
 | ----------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- | ----------- |
-| `current`         | `current`           | ID of the current active item.                                                                                                                         | `string`                                                   | `undefined` |
+| `current`         | `current`           | Path of the current item.                                                                                                                              | `string`                                                   | `undefined` |
 | `data`            | `data`              | The data to build the menu (as an array of `MenubarItem` or a JSON array) or the url to fetch to retrieve it.                                          | `MenubarItem[] \| Promise<MenubarItem[]> \| URL \| string` | `undefined` |
 | `mouseOutTimeout` | `mouse-out-timeout` | Delay in milliseconds before closing the menu after a mouseout event. Useful to avoid immediate closing when the pointer briefly leaves the component. | `number`                                                   | `1000`      |
 | `searchQuery`     | `search-query`      | Initial search query.                                                                                                                                  | `string`                                                   | `undefined` |
-| `via`             | `via`               | The path of current item, used to solve ubiquity and determine the right active element.                                                               | `string`                                                   | `undefined` |
 
 
 ## Dependencies

--- a/src/index.html
+++ b/src/index.html
@@ -37,7 +37,7 @@
 
   <body>
     <header>
-      <zanit-menubar current="per-chi-insegna"></zanit-menubar>
+      <zanit-menubar current="scuola/per-chi-studia-4457ef/ciao-manuel"></zanit-menubar>
       <script>
         document.addEventListener('DOMContentLoaded', function () {
           document.querySelector('zanit-menubar')?.setAttribute(
@@ -45,110 +45,249 @@
             JSON.stringify([
               {
                 label: 'Scuola',
-                href: 'https://localhost.zanichelli.it:3000/scuola',
+                href: 'https://test-www.aglebert.zanichelli.it/scuola',
                 id: 'scuola',
+                highlight: false,
                 navbarItems: [
                   {
                     label: 'Per chi insegna',
-                    href: 'https://localhost.zanichelli.it:3000/per-chi-insegna',
-                    id: 'per-chi-insegna',
+                    href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-insegna',
+                    id: 'per-chi-insegna-fb74aa',
+                    highlight: false,
                     menuItems: [
                       {
-                        label: 'Perché è difficile riconoscere le fake news in Rete?',
-                        href: 'https://localhost.zanichelli.it:3000/perche-e-difficile-riconoscere-le-fake-news-in-rete',
-                        id: 'perche-e-difficile-riconoscere-le-fake-news-in-rete',
-                        highlight: true,
-                        group: { id: 'in-evidenza', label: 'In evidenza' },
-                      },
-                      {
-                        label: 'Dalla correlazione alla causalita applicazione al caso del global warming',
-                        href: 'https://localhost.zanichelli.it:3000/dalla-correlazione-alla-causalita-applicazione-al-caso-del-global-warming',
-                        id: 'dalla-correlazione-alla-causalita-applicazione-al-caso-del-global-warming',
-                        highlight: true,
-                        group: { id: 'in-evidenza', label: 'In evidenza' },
-                      },
-                      {
-                        label: 'esplora, crea, connetti con laZ',
-                        href: 'https://localhost.zanichelli.it:3000/laz',
+                        label: 'laZ',
+                        href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-insegna/laz',
                         id: 'laz',
+                        group: {
+                          label: 'In evidenza',
+                          id: 'in-evidenza',
+                        },
+                        highlight: true,
                       },
                       {
                         label: 'Obiettivi formativi',
-                        href: 'https://localhost.zanichelli.it:3000/obiettivi-formativi',
+                        href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-insegna/obiettivi-formativi',
                         id: 'obiettivi-formativi',
+                        highlight: false,
                       },
                       {
-                        label: 'Cacciatori di bufale (si diventa)',
-                        href: 'https://localhost.zanichelli.it:3000/cacciatori-di-bufale-si-diventa',
+                        label: 'cacciatori',
+                        href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-insegna/cacciatori-di-bufale-si-diventa',
                         id: 'cacciatori-di-bufale-si-diventa',
                         group: {
-                          id: '6-acqua-pulita-e-servizi-igienico-sanitari',
                           label: '6 Acqua pulita e servizi igienico-sanitari',
+                          id: 'agenda2030-acqua-pulita-servizi-igienico-sanitari',
                         },
+                        highlight: false,
+                      },
+                      {
+                        label: 'Perché è difficile riconoscere le fake news in Rete?',
+                        href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-insegna/perche-e-difficile-riconoscere-le-fake-news-in-rete',
+                        id: 'perche-e-difficile-riconoscere-le-fake-news-in-rete',
+                        group: {
+                          label: '4 Istruzione di qualità',
+                          id: 'agenda2030-istruzione-di-qualita',
+                        },
+                        highlight: false,
+                      },
+                      {
+                        label: 'Dalla correlazione alla causalita applicazione al caso del global warming',
+                        href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-insegna/dalla-correlazione-alla-causalita-applicazione-al-caso-del-global-warming',
+                        id: 'dalla-correlazione-alla-causalita-applicazione-al-caso-del-global-warming',
+                        group: {
+                          label: '4 Istruzione di qualità',
+                          id: 'agenda2030-istruzione-di-qualita',
+                        },
+                        highlight: false,
                       },
                       {
                         label: 'Documento con copertina',
-                        href: 'https://localhost.zanichelli.it:3000/documento-con-copertina',
+                        href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-insegna/documento-con-copertina',
                         id: 'documento-con-copertina',
+                        highlight: false,
+                      },
+                      {
+                        label: 'Offerta per Bisogni Educativi Speciali',
+                        href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-insegna/offerta-per-bisogni-educativi-speciali',
+                        id: 'offerta-per-bisogni-educativi-speciali',
+                        highlight: false,
+                      },
+                      {
+                        label: 'Filiali & Filiali',
+                        href: 'https://test-www.aglebert.zanichelli.it/contatti/filiali-e-agenzie/',
+                        id: 'filiali-e-filiali',
+                        highlight: false,
+                      },
+                      {
+                        label: 'Servizi',
+                        href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-insegna/servizi',
+                        id: 'servizi',
+                        highlight: false,
+                      },
+                      {
+                        label: 'prova manuel',
+                        href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-insegna/prova-manuel',
+                        id: 'prova-manuel',
+                        highlight: false,
+                      },
+                      {
+                        label: 'Collezioni',
+                        href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-insegna/collezioni-64748c',
+                        id: 'collezioni-64748c',
+                        highlight: false,
+                      },
+                      {
+                        label: 'Ciao manuel',
+                        href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-insegna/ciao-manuel',
+                        id: 'ciao-manuel',
+                        group: {
+                          label: 'Proposta editorale',
+                          id: 'proposta-editoriale',
+                        },
+                        highlight: false,
+                      },
+                      {
+                        label: 'Prova di Paolo di Prova',
+                        href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-insegna/pdpdp',
+                        id: 'pdpdp',
+                        highlight: false,
                       },
                     ],
                   },
                   {
                     label: 'Per chi studia',
-                    href: 'https://localhost.zanichelli.it:3000/per-chi-studia-4457ef',
+                    href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-studia',
                     id: 'per-chi-studia-4457ef',
-                    menuItems: [],
+                    highlight: false,
+                    menuItems: [
+                      {
+                        label: 'PNRR 2023-2024',
+                        href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-studia/pnrr-2023-2024',
+                        id: 'pnrr-2023-2024',
+                        highlight: false,
+                      },
+                      {
+                        label: 'Siti LaZ',
+                        href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-studia/laz',
+                        id: 'siti-laz',
+                        highlight: false,
+                      },
+                      {
+                        label: 'Ciao manuel',
+                        href: 'https://test-www.aglebert.zanichelli.it/scuola/per-chi-studia/ciao-manuel',
+                        id: 'ciao-manuel',
+                        group: {
+                          label: 'Proposta editorale',
+                          id: 'proposta-editoriale',
+                        },
+                        highlight: false,
+                      },
+                    ],
                   },
                   {
                     label: 'Per le scuole',
-                    href: 'https://localhost.zanichelli.it:3000/per-le-scuole',
+                    href: 'https://test-www.aglebert.zanichelli.it/scuola/per-le-scuole',
                     id: 'per-le-scuole',
+                    highlight: false,
                     menuItems: [
                       {
                         label: 'La nostra proposta per i Bisogni Educativi Speciali',
-                        href: 'https://localhost.zanichelli.it:3000/longformtestfrappa',
+                        href: 'https://test-www.aglebert.zanichelli.it/scuola/per-le-scuole/longformtestfrappa',
                         id: 'longformtestfrappa',
+                        highlight: false,
                       },
                     ],
                   },
                   {
                     label: 'Per le librerie',
-                    href: 'https://localhost.zanichelli.it:3000/per-le-librerie',
+                    href: 'https://test-www.aglebert.zanichelli.it/scuola/per-le-librerie',
                     id: 'per-le-librerie',
+                    highlight: false,
                     menuItems: [],
                   },
                 ],
               },
               {
                 label: 'Università',
-                href: 'https://localhost.zanichelli.it:3000/universita',
+                href: 'https://test-www.aglebert.zanichelli.it/universita',
                 id: 'universita',
-                menuItems: [],
+                highlight: false,
+                navbarItems: [
+                  {
+                    label: 'Per chi insegna',
+                    href: 'https://test-www.aglebert.zanichelli.it/universita/per-chi-insegna',
+                    id: 'per-chi-insegna-5b3787',
+                    highlight: false,
+                    menuItems: [],
+                  },
+                  {
+                    label: 'Per chi studia',
+                    href: 'https://test-www.aglebert.zanichelli.it/universita/per-chi-studia',
+                    id: 'per-chi-studia-86b006',
+                    highlight: false,
+                    menuItems: [
+                      {
+                        label: 'Ciao manuel',
+                        href: 'https://test-www.aglebert.zanichelli.it/universita/per-chi-studia/ciao-manuel',
+                        id: 'ciao-manuel',
+                        group: {
+                          label: 'Proposta editorale',
+                          id: 'proposta-editoriale',
+                        },
+                        highlight: false,
+                      },
+                    ],
+                  },
+                ],
               },
               {
                 label: 'Giuridico',
-                href: 'https://localhost.zanichelli.it:3000/giuridico',
+                href: 'https://test-www.aglebert.zanichelli.it/giuridico',
                 id: 'giuridico',
+                highlight: false,
                 menuItems: [
                   {
+                    label: 'Contatti',
+                    href: 'https://test-www.aglebert.zanichelli.it/giuridico/contatti-c0b9ed',
+                    id: 'contatti-c0b9ed',
+                    group: {
+                      label: 'In evidenza',
+                      id: 'in-evidenza',
+                    },
+                    highlight: true,
+                  },
+                  {
                     label: 'Manuali universitari',
-                    href: 'https://localhost.zanichelli.it:3000/manuali-universitari',
+                    href: 'https://test-www.aglebert.zanichelli.it/giuridico/manuali-universitari',
                     id: 'manuali-universitari',
-                    group: { id: 'gruppo-1', label: 'gruppo 1' },
+                    group: {
+                      label: 'Primo biennio',
+                      id: 'secondaria-2-grado-biennio',
+                    },
+                    highlight: false,
                     navbarItems: [],
                   },
                   {
                     label: 'Notiziario zanichelli',
-                    href: 'https://localhost.zanichelli.it:3000/notiziario-zanichelli-ea8873',
+                    href: 'https://test-www.aglebert.zanichelli.it/giuridico/notiziario-zanichelli-ea8873',
                     id: 'notiziario-zanichelli-ea8873',
+                    highlight: false,
                     navbarItems: [],
+                  },
+                  {
+                    label: 'Sostenibilità ambientale - 7',
+                    href: 'https://test-www.aglebert.zanichelli.it/giuridico/sostenibilita-ambientale-7-9881c1',
+                    id: 'sostenibilita-ambientale-7-9881c1',
+                    highlight: false,
                   },
                 ],
               },
               {
                 label: 'Saggistica',
-                href: 'https://localhost.zanichelli.it:3000/saggistica',
+                href: 'https://test-www.aglebert.zanichelli.it/saggistica',
                 id: 'saggistica',
+                highlight: false,
                 menuItems: [],
               },
             ])


### PR DESCRIPTION
This PR solves ubiquity of active menu items. The `current` prop now accepts a full path to reach the currently visited object instead of using only its ID.