### PR TITLE
Bump version, release 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zanichelli/zanichelli-it-frontend-kit",
-  "version": "0.1.6",
+  "version": "1.0.0",
   "description": "Zanichelli.it frontend kit",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This PR bumps the version in `package.json` to mark reaching a stable release.