### PR TITLE
fix(accessibility): add complete border to search button for WCAG 1.4.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zanichelli/zanichelli-it-frontend-kit",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Zanichelli.it frontend kit",
   "license": "MIT",
   "repository": {

--- a/src/components/menubar/menubar.tsx
+++ b/src/components/menubar/menubar.tsx
@@ -541,7 +541,10 @@ export class ZanitMenubar {
           .map(
             (item) =>
               item.navbarItems?.length && (
-                <nav class={{ 'sub-menubar': true, 'shadow-wrapper': true }} aria-label={`Sezioni: ${item.label}`}>
+                <nav
+                  class={{ 'sub-menubar': true, 'shadow-wrapper': true }}
+                  aria-label={`Sezioni: ${item.label}`}
+                >
                   <ul role="menubar">
                     {item.navbarItems.map((subitem) => (
                       <Fragment>

--- a/src/components/menubar/search-form/search-form.css
+++ b/src/components/menubar/search-form/search-form.css
@@ -19,8 +19,8 @@ button {
   --searchbar-button-x-padding: 14px;
   --searchbar-button-icon-width: 1.75rem;
 
-  /* button horizontal padding + icon size + left border */
-  --closed-searchbar-width: calc((var(--searchbar-button-x-padding) * 2) + var(--searchbar-button-icon-width) + 1px);
+  /* button horizontal padding + icon size + borders */
+  --closed-searchbar-width: calc((var(--searchbar-button-x-padding) * 2) + var(--searchbar-button-icon-width) + 2px);
 
   position: absolute;
   top: 0;
@@ -94,7 +94,7 @@ button {
   align-items: center;
   justify-content: center;
   padding: 10px var(--searchbar-button-x-padding);
-  border-left: 1px solid #000;
+  border: 1px solid #000;
   background: var(--zanit-accent-color);
   font-family: inherit;
   font-size: inherit;
@@ -145,11 +145,5 @@ button {
 @media (width >= 1152px) {
   .searchbar {
     --closed-searchbar-width: 190px;
-  }
-}
-
-@media (width >= 1366px) {
-  .searchbar .searchbar-button {
-    border-right: 1px solid #000;
   }
 }


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.4.11 (Non-text Contrast)** by adding a complete border around the yellow search button to ensure sufficient contrast with the white background.

**Issue**: The yellow "Cerca" search button fails WCAG 1.4.11 requirements. The button only had a left border (and right border at wider viewports), resulting in insufficient contrast (<3:1) between the yellow background and adjacent white page background.

**Solution**: Changed `border-left: 1px solid #000` to `border: 1px solid #000` to create a complete border around the search button at all viewport sizes.

## Changes

- **search-form.css**: Changed from border-left to complete border
- **search-form.css**: Removed redundant border-right media query (no longer needed)
- **search-form.css**: Updated width calculation to account for 2px (left + right borders)
- **package.json**: Bumped version to 1.1.2

## Test Plan

- [x] Verified complete border provides 3:1 contrast ratio with white background
- [x] Tested at multiple viewport sizes (mobile, tablet, desktop)
- [x] Confirmed keyboard navigation and focus states remain functional
- [x] Linting passes

## Evidence

View before screenshots and full audit details:
https://app.workback.ai/issues/tg7fnt4m4cggonkoaqyrw3y6sw/

## WCAG Reference

[1.4.11 Non-text Contrast (Level AA)](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html)
