### PR TITLE
fix(search-form): maintain consistent navigation structure

### DIFF
--- a/src/components/menubar/menubar.tsx
+++ b/src/components/menubar/menubar.tsx
@@ -541,7 +541,10 @@ export class ZanitMenubar {
           .map(
             (item) =>
               item.navbarItems?.length && (
-                <nav class={{ 'sub-menubar': true, 'shadow-wrapper': true }} aria-label={`Sezioni: ${item.label}`}>
+                <nav
+                  class={{ 'sub-menubar': true, 'shadow-wrapper': true }}
+                  aria-label={`Sezioni: ${item.label}`}
+                >
                   <ul role="menubar">
                     {item.navbarItems.map((subitem) => (
                       <Fragment>

--- a/src/components/menubar/search-form/search-form.css
+++ b/src/components/menubar/search-form/search-form.css
@@ -64,6 +64,10 @@ button {
   cursor: pointer;
 }
 
+.searchbar button.reset-button-hidden {
+  visibility: hidden;
+}
+
 .searchbar input {
   z-index: 1;
   width: 100%;

--- a/src/components/menubar/search-form/search-form.tsx
+++ b/src/components/menubar/search-form/search-form.tsx
@@ -118,15 +118,14 @@ export class ZanitSearchForm {
           class="input-wrapper"
           role="none"
         >
-          {this.searchQuery && (
-            <button
-              type="reset"
-              aria-label="Svuota campo di ricerca"
-              disabled={!this.showSearchbar}
-            >
-              <z-icon name="multiply-circled" />
-            </button>
-          )}
+          <button
+            type="reset"
+            class={{ 'reset-button': true, 'reset-button-hidden': !this.searchQuery }}
+            aria-label="Svuota campo di ricerca"
+            disabled={!this.showSearchbar}
+          >
+            <z-icon name="multiply-circled" />
+          </button>
           <input
             id="searchbar-input"
             name="q"


### PR DESCRIPTION
## Summary

Fixes **WCAG 3.2.3 (Consistent Navigation)** by ensuring the search field structure remains consistent across all pages in the checkout flow.

**Issue**: The "Svuota campo di ricerca" (Clear search) button was conditionally rendered only when a search query existed, causing the navigation structure to change between pages (present on steps 1-10, absent on confirmation page step 11).

**Solution**: The clear button is now always present in the DOM. When there is no search query, it is hidden using CSS `visibility: hidden` instead of being removed from the DOM. This maintains consistent navigation structure while preserving the same visual appearance.

## Changes

- Modified `search-form.tsx` to always render the reset button with a `reset-button-hidden` class when empty
- Updated `search-form.css` to use `visibility: hidden` for hiding the button instead of conditional rendering

## Test Plan

- [x] Build succeeds without errors
- [x] Linting passes (ESLint, Stylelint, Prettier)
- [x] Search functionality works as expected
- [x] Button appears when search query exists
- [x] Button is hidden (but present in DOM) when no search query
- [x] Keyboard navigation remains consistent

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/56/

---

**WCAG Reference:**
[3.2.3 Consistent Navigation (Level AA)](https://www.w3.org/WAI/WCAG21/Understanding/consistent-navigation.html)