### PR TITLE
Fix navigation issue for suggestions from sub-paths

### DIFF
--- a/src/components/menubar/search-form/suggestions.ts
+++ b/src/components/menubar/search-form/suggestions.ts
@@ -80,7 +80,7 @@ const buildId = (string: string) =>
     .join('');
 
 const buildUrl = (params: Record<string, string>): string => {
-  return `ricerca?${new URLSearchParams(params).toString()}`;
+  return `/ricerca?${new URLSearchParams(params).toString()}`;
 };
 
 const buildDetail = (user_query: string, query?: string, area?: string, subject?: string) => ({


### PR DESCRIPTION
This pull request makes a small update to the `buildUrl` function in `src/components/menubar/search-form/suggestions.ts`, ensuring that generated search URLs are now absolute paths by adding a leading slash.

This fixes an issue when clicking on suggestions from a sub-path (e.g. `/scuola/`).