### PR TITLE
fix(search-form): always render reset button for consistent navigation

### DIFF
--- a/src/components/menubar/search-form/search-form.css
+++ b/src/components/menubar/search-form/search-form.css
@@ -66,6 +66,10 @@ button {
   cursor: pointer;
 }
 
+.searchbar button.reset-button-hidden {
+  visibility: hidden;
+}
+
 .searchbar input {
   z-index: 1;
   width: 100%;

--- a/src/components/menubar/search-form/search-form.tsx
+++ b/src/components/menubar/search-form/search-form.tsx
@@ -330,17 +330,16 @@ export class ZanitSearchForm implements ComponentInterface {
             class="input-wrapper"
             role="none"
           >
-            {this.searchQuery && (
-              <button
-                type="reset"
-                aria-label="Svuota campo di ricerca"
-                disabled={!this.showSearchbar}
-                aria-hidden={!this.showSearchbar ? 'true' : undefined}
-                tabIndex={!this.showSearchbar ? -1 : 0}
-              >
-                <z-icon name="multiply-circled" />
-              </button>
-            )}
+            <button
+              type="reset"
+              class={{ 'reset-button-hidden': !this.searchQuery }}
+              aria-label="Svuota campo di ricerca"
+              disabled={!this.showSearchbar}
+              aria-hidden={!this.showSearchbar ? 'true' : undefined}
+              tabIndex={!this.showSearchbar ? -1 : 0}
+            >
+              <z-icon name="multiply-circled" />
+            </button>
             <input
               id="searchbar-input"
               name="q"


### PR DESCRIPTION
## Summary

Fixes **WCAG 3.2.3 (Consistent Navigation)** by ensuring the search field structure remains consistent across all pages.

**Issue**: The "Svuota campo di ricerca" (Clear search) button was conditionally rendered only when a search query existed, causing its complete removal from the DOM on pages without a query (e.g., order confirmation page). This changed the navigation structure between pages.

**Solution**: The reset button is now always present in the DOM. When there is no search query, it is hidden using CSS `visibility: hidden` instead of being removed. This maintains consistent navigation structure while preserving the same visual appearance.

Replaces #23, which had merge conflicts with main.

## Changes

- **search-form.tsx**: Removed conditional `{this.searchQuery && (...)}` wrapper around the reset button. Added `reset-button-hidden` CSS class when query is empty.
- **search-form.css**: Added `.searchbar button.reset-button-hidden { visibility: hidden; }` rule to visually hide the button while keeping it in the DOM.

## Test Plan

- [x] Build succeeds (`pnpm build`)
- [x] Reset button always present in DOM (verified via accessibility tree)
- [x] Button is visually hidden when no search query
- [x] Button is visible and functional when search query exists
- [x] Keyboard navigation remains consistent across pages

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/issues/95tf9zuji2z3rcmnfsdxrabm5h/

---

**WCAG Reference:**
[3.2.3 Consistent Navigation (Level AA)](https://www.w3.org/WAI/WCAG21/Understanding/consistent-navigation.html)