### PR TITLE
fix(search): add bottom border for WCAG 1.4.11 compliance

### DIFF
--- a/src/components/menubar/search-form/search-form.css
+++ b/src/components/menubar/search-form/search-form.css
@@ -96,6 +96,7 @@ button {
   align-items: center;
   justify-content: center;
   padding: 10px var(--searchbar-button-x-padding);
+  border-bottom: 1px solid #000;
   border-left: 1px solid #000;
   background: var(--zanit-accent-color);
   font-family: inherit;


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.4.11 (Non-text Contrast)** by adding a bottom border to the yellow search button.

**Issue**: The yellow search button ("Cerca") background (`#FFD500`) has ~1.4:1 contrast against the adjacent white background, failing the 3:1 minimum. The existing `box-shadow` (`rgba(61,61,61,0.35)`) blends to ~`#BBBBBB` over white, yielding only ~1.88:1 — still below 3:1.

**Solution**: Adds `border-bottom: 1px solid #000` to `.searchbar-button`. Only the bottom edge needs a border because:
- **Top**: The dark topbar (`#292929`) already provides ~10:1 contrast
- **Left**: Already has `border-left: 1px solid #000`
- **Right**: Has `border-right` at `≥ 1366px`; at narrower viewports the button is flush with the viewport edge

## Test Plan

- [x] Verified bottom border renders at all viewport sizes
- [x] Confirmed keyboard navigation remains functional
- [x] Validated 3:1 contrast ratio meets WCAG 1.4.11

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/issues/tg7fnt4m4cggonkoaqyrw3y6sw/

---

**WCAG Reference:**
[1.4.11 Non-text Contrast](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html)